### PR TITLE
allow all winning words

### DIFF
--- a/react-hardle/src/store/Hardle.js
+++ b/react-hardle/src/store/Hardle.js
@@ -75,7 +75,7 @@ var store = {
         break;
       case "Enter":
         if (currentWord.length === 5) {
-          if (HardleWords.allWords.includes(currentWord)) {
+          if (HardleWords.allWords.includes(currentWord) || HardleWords.secretWords.includes(currentWord)) {
             this.guessCount += 1;
             this.onWinLoss();
           } else {


### PR DESCRIPTION
Today's winning word wasn't an allowed word. This is quick fix to make sure all winning words are valid. 